### PR TITLE
fixed searchbnf / inline help

### DIFF
--- a/default/commands.conf
+++ b/default/commands.conf
@@ -1,3 +1,4 @@
 [html2text]
 filename = html2text.py
-streaming=true
+supports_getinfo = true
+streaming = true

--- a/default/searchbnf.conf
+++ b/default/searchbnf.conf
@@ -1,7 +1,9 @@
 [html2text-command]
 syntax = html2text (field1 field2 ...)
+shortdesc = Convert fields with HTML into plain text.
 description = Convert fields with HTML into plain text.  If no field names are specified, html2text is run on all fields.
+comment1 = remove all HTML tags in the field named EmailBody.
+example1 = ... | html2text EmailBody
 usage = public
-example1 = html2text EmailBody
-comment1 = All the HTML fields in EmailBody are removed.
 tags = html sanitize clean
+category = charting

--- a/metadata/default.meta
+++ b/metadata/default.meta
@@ -1,4 +1,7 @@
-[commands/html2text]
+[commands]
 access = read : [ * ], write : [ admin ]
 export = system
 
+[searchbnf]
+access = read : [ * ], write : [ admin ]
+export = system


### PR DESCRIPTION
Added stanza in default.meta to cover searchbnf stanza - this fixes the SPL lookahead, tested working in Splunk 7.2..

Further rewritten some of the help texts to be more precise.